### PR TITLE
fixed up gps, shouldn't fail anymore if it does im burning it all down

### DIFF
--- a/firmware/SealHAT/main.c
+++ b/firmware/SealHAT/main.c
@@ -41,13 +41,13 @@ int main(void)
 
     // start the ECG
     if(ECG_task_init() != ERR_NONE) {
-        while(1) {;}
+        gpio_set_pin_level(LED_RED, true);  // will never work if there is no device, shouldn't go into a while(1)
     }
 
     // GPS task init
-//     if(GPS_task_init(0) != ERR_NONE) {
-//         while(1) {;}
-//     }
+    if(GPS_task_init(0) != ERR_NONE) {
+        while(1) {;}
+    }
 
     // IMU task init.
     if(IMU_task_init(ACC_SCALE_2G, ACC_HR_50_HZ, MAG_LP_20_HZ) != ERR_NONE) {

--- a/firmware/SealHAT/tasks/seal_GPS.c
+++ b/firmware/SealHAT/tasks/seal_GPS.c
@@ -17,31 +17,30 @@ static StaticTimer_t xGPS_timerbuf;      // static buffer to hold timer state
 
 int32_t GPS_task_init(void *profile)
 {
-    uint32_t samplerate;
     int32_t err;    /* for catching API errors */
-
-    eeprom_data.config_settings.gps_config.gps_restRate = 75000;
+    
+    // TODO - remove when EEPROM is configured
+    eeprom_data.config_settings.gps_config.gps_restRate = 75000; 
     eeprom_data.config_settings.gps_config.gps_moveRate = 30000;
 
-    samplerate = eeprom_data.config_settings.gps_config.gps_moveRate;
     /* initialize the GPS module */
+    gpio_set_pin_level(GPS_EXT_INT, false);
     err = gps_init_i2c(&I2C_GPS) ? ERR_NOT_INITIALIZED : ERR_NONE;
 
     /* force the GPS to stay awake until configuration is complete */
     gpio_set_pin_level(GPS_EXT_INT, true);
 
     /* verify/load GPS settings, set up NAV polling, and disable output for now */
-    portENTER_CRITICAL();
     if (ERR_NONE == err && GPS_SUCCESS != gps_checkconfig()) {
-        err =   gps_reconfig(samplerate) ? ERR_NOT_READY : ERR_NONE;  // TODO change to 0
+        err =   gps_reconfig() ? ERR_NOT_READY : ERR_NONE;  // TODO change to 0
     }
-    portEXIT_CRITICAL();
 
-    // TODO what to do if this fails? Should be handled in SW
-    if (err) {
+    if (err) { // TODO what to do if this fails? Should be handled in SW  
         gpio_toggle_pin_level(LED_RED);
     } else {
-
+        /* save configurations */
+        gps_savecfg(0xFFFF);
+        
         /* create a timer with a one hour period for controlling sensors */
         configASSERT(!configUSE_16_BIT_TICKS);
         xGPS_timer = xTimerCreateStatic(   "GPSTimer",                 /* text name of the timer       */
@@ -50,16 +49,16 @@ int32_t GPS_task_init(void *profile)
                                             (void*)0,                   /* id of expiration counter     */
                                             GPS_movement_cb,            /* timer expiration callback    */
                                             &xGPS_timerbuf);           /* timer data buffer            */
-
+        
         if (NULL == xGPS_timer) { /* if the timer was not created */
             err = DEVICE_ERR_TIMEOUT; // TODO determine proper handling
         }
-
+        
         /* create the task, return ERR_NONE or ERR_NO_MEMORY if the task creation failed */
         xGPS_th = xTaskCreateStatic(GPS_task, "GPS", GPS_STACK_SIZE, (void *)profile, GPS_TASK_PRI, xGPS_stack, &xGPS_taskbuf);
         configASSERT(xGPS_th);
     }
-
+    
     return err;
 }
 
@@ -67,131 +66,156 @@ void GPS_task(void *pvParameters)
 {
     uint16_t    activehours;        /* number of hours in a day the gps is on   */
     uint16_t    moveminutes;        /* high resolution time(m) allowed per hour */
-    uint16_t    blocktime;          /* time that the gps task will block for    */
     uint32_t    samplerate;         /* rate to collect fix and report message   */
     uint32_t    ulNotifyValue;      /* holds the notification bits from the ISR */
     int32_t     err;                /* for catching API errors                  */
     BaseType_t  xResult;            /* holds return value of blocking function  */
     TickType_t  xMaxBlockTime;      /* max time to wait for the task to resume  */
     static GPS_MSG_t gps_msg;	    /* holds the GPS message to store in flash  */
-
+    
     (void)pvParameters;
     activehours = 0;
     eeprom_data.config_settings.gps_config.gps_restRate = 75000;    // TODO remove after EEPROM is set
     eeprom_data.config_settings.gps_config.gps_moveRate = 30000;    // TODO remove after EEPROM is set
-
+    
     for(int i = 0; i < 24; i++) {   /* determine the amount of active hours per day */
         activehours += (eeprom_data.config_settings.gps_config.gps_activeHour >> i) & 1;
     }
     activehours = 24; // TODO remove, testing only
     moveminutes = GPS_MAXMOVE / activehours;   /* determine the high-res time per hour */
-
+    
     /* set the default sample rate */ // TODO: allow flexibility in message rate or fix to sample rate
     samplerate = eeprom_data.config_settings.gps_config.gps_restRate;
 
     /* update the maximum blocking time to current FIFO full time + <max sensor time> */
-    blocktime     = 2000;
-    xMaxBlockTime = pdMS_TO_TICKS(samplerate - blocktime);	    // TODO calculate based on registers
+    xMaxBlockTime = pdMS_TO_TICKS(samplerate);	    // TODO calculate based on registers
 
     /* initialize the message header */
     dataheader_init(&gps_msg.header);
     gps_msg.header.id  = DEVICE_ID_GPS;
 
-    /* clear the GPS FIFO */
-    gps_checkfifo();
-    gps_loadcfg(0xFFFF);
-    gps_readfifo();
-
     /* ensure the TX_RDY interrupt is deactivated */
     gpio_set_pin_level(GPS_TXD, true);
-
+    
+    /* clear the GPS FIFO before enabling interrupt */
+    gps_readfifo();
+    
     /* enable the data ready interrupt (TxReady) */
     ext_irq_register(GPS_TXD, GPS_isr_dataready);
-
+    
+    /* put the device to sleep until its period is up */
+    gpio_set_pin_level(GPS_EXT_INT, false);
+    gps_nap(samplerate);
     for (;;) {
-        /* put the GPS device to sleep until an interrupting event */
-        gpio_set_pin_level(GPS_EXT_INT, false);
-
         /* wait for notification from ISR, returns `pdTRUE` if task, else `pdFALSE` */
         xResult = xTaskNotifyWait( GPS_NOTIFY_NONE, /* bits to clear on entry       */
                                    GPS_NOTIFY_ALL,  /* bits to clear on exit        */
                                    &ulNotifyValue,  /* stores the notification bits */
                                    xMaxBlockTime ); /* max wait time before error   */
 
-        /* keep the GPS awake until the interrupt is handled */
-        gpio_set_pin_level(GPS_EXT_INT, true);
-        err = gps_checkfifo();
-        gps_loadcfg(0xFFFF);
-
-        if (pdPASS == xResult) { /* there was an interrupt */
-
-            /* reload the high-res movement minutes if needed */
+        
+        if (pdPASS == xResult) { /* there was an interrupt before the rest period was up */
+            
+            /* if requested, reload the high-res movement minutes */
             if (GPS_NOTIFY_HOUR & ulNotifyValue) {
                 moveminutes = GPS_MAXMOVE / activehours;
             }
-
+            
             /* if the ISR indicated that data is ready */
             if (GPS_NOTIFY_TXRDY & ulNotifyValue) {
+                /* keep the GPS awake until the interrupt is handled */
+                gpio_set_pin_level(GPS_EXT_INT, true);
 
                 /* copy the GPS FIFO over I2C */
-                gps_checkfifo();
-                os_sleep(pdMS_TO_TICKS(1000));
                 err = gps_readfifo() ? ERR_TIMEOUT : ERR_NONE;
 
+                /* put device back to sleep */
+                gpio_set_pin_level(GPS_EXT_INT, false);
+                gps_nap(samplerate);
+                
                 /* and log it, noting communication error if needed */
                 GPS_log(&gps_msg, err, DEVICE_ERR_COMMUNICATIONS);
+                xMaxBlockTime = pdMS_TO_TICKS(samplerate);
             }
-
+            
             /* if motion has been detected by the IMU */
             if (GPS_NOTIFY_MOTION & ulNotifyValue && moveminutes) {
                 /* block the state machine from sending another rate change request */
                 xEventGroupSetBits(xSYSEVENTS_handle, EVENT_GPS_COOLDOWN);
-
+                
+                /* keep the GPS awake until the interrupt is handled */
+                gpio_set_pin_level(GPS_EXT_INT, true);
+                
                 /* decrement the available high-res minutes and set the rate */
                 moveminutes--;
                 samplerate = eeprom_data.config_settings.gps_config.gps_moveRate;
                 err = gps_setrate(samplerate) ? ERR_NO_CHANGE : ERR_NONE;
-
-                /* if failure, try again. else start a one minute timer */
+                
+                /* if failure, try again. else save configurations and start a one minute timer */
                 if(err) {
                     xTaskNotify(xGPS_th, GPS_NOTIFY_MOTION, eSetBits);
                 } else {
                     gps_savecfg(0xFFFF);
+                    
+                    /* put device back to sleep */
+                    gpio_set_pin_level(GPS_EXT_INT, false);
+                    gps_nap(samplerate);
+                    
                     xMaxBlockTime = pdMS_TO_TICKS(samplerate);
                     xTimerChangePeriod(xGPS_timer, pdMS_TO_TICKS(60000), 0);
                 }
             }
-
+            
             /* if the high precision motion timer has expired */
             if (GPS_NOTIFY_REVERT & ulNotifyValue) {
+                /* keep the GPS awake until the interrupt is handled */
+                gpio_set_pin_level(GPS_EXT_INT, true);
+                
                 /* revert the rate back to the resting rate */
                 samplerate = eeprom_data.config_settings.gps_config.gps_restRate;
                 err = gps_setrate(samplerate) ? ERR_NO_CHANGE : ERR_NONE;
-
+                
                 /* try again if not successful */
                 if (err) {
                     xTaskNotify(xGPS_th, GPS_NOTIFY_REVERT, eSetBits);
                 } else {
                     gps_savecfg(0xFFFF);
+                    
+                    /* put device back to sleep */
+                    gpio_set_pin_level(GPS_EXT_INT, false);
+                    gps_nap(samplerate);
+                    
                     xMaxBlockTime = pdMS_TO_TICKS(samplerate);
                 }
             }
-
-        } else { /* the interrupt timed out, figure out why and log */
-            /* check how many samples are in the FIFO */
-
-            if (0 > err) {
-                /* if the GPS doesn't respond, try again soon */
-                xMaxBlockTime = pdMS_TO_TICKS(blocktime);
-            } else if (GPS_FIFOSIZE < err) {
-                /* if the FIFO has "overflown", clear and log error */
-                err = gps_readfifo() ? ERR_TIMEOUT : ERR_NONE;
-                GPS_log(&gps_msg, err, DEVICE_ERR_OVERFLOW | DEVICE_ERR_TIMEOUT);
-            } else {
-                /* GPS is responsive, allow full sleep cycle */
-                xMaxBlockTime = pdMS_TO_TICKS(samplerate - blocktime);
-                xTaskNotify(xGPS_th, GPS_NOTIFY_TXRDY, eSetBits);
-            }
+        } else { /* there was no interrupt and the GPS has slept for one period */
+            gpio_set_pin_level(GPS_EXT_INT, true);
+            os_sleep(5);
+            
+            /* if it is the first wakeup */
+            if (xMaxBlockTime == samplerate) {   
+                /* load fix settings and wait for a fix/FIFO interrupt */
+                gps_loadcfg(0xFFFF);
+                gpio_set_pin_level(GPS_EXT_INT, false);
+                xMaxBlockTime = pdMS_TO_TICKS(GPS_WAIT_TIME); /* allow time to receive a fix */
+            } else { 
+                /* there was no fix, resolve timeout error */
+                err = gps_checkfifo();
+                gpio_set_pin_level(GPS_EXT_INT, false);
+                if (0 > err) {
+                    /* if the GPS doesn't respond, try again soon */
+                    xMaxBlockTime = pdMS_TO_TICKS(GPS_WAIT_TIME);
+                } else if (GPS_FIFOSIZE < err) {
+                    /* if the FIFO has "overflown", clear and log error */
+                    err = gps_readfifo() ? ERR_TIMEOUT : ERR_NONE;
+                    GPS_log(&gps_msg, err, DEVICE_ERR_OVERFLOW | DEVICE_ERR_TIMEOUT);
+                    gps_nap(samplerate);
+                } else {
+                    /* GPS is responsive, allow full sleep cycle */
+                    xMaxBlockTime = pdMS_TO_TICKS(samplerate);
+                    xTaskNotify(xGPS_th, GPS_NOTIFY_TXRDY, eSetBits);
+                }
+            }            
         }
     } // END FOREVER LOOP
 }
@@ -212,10 +236,10 @@ void GPS_isr_dataready(void)
 void GPS_movement_cb(TimerHandle_t xTimer)
 {
     configASSERT(xTimer);
-
+    
     /* allow the GPS to receive IMU events again */
     xEventGroupClearBits(xSYSEVENTS_handle, EVENT_GPS_COOLDOWN);
-
+    
     /* tell the GPS to revert to resting rate, try again if busy */
     xTaskNotify(xGPS_th, GPS_NOTIFY_REVERT, eSetBits);
 }
@@ -228,7 +252,7 @@ int32_t GPS_log(GPS_MSG_t *msg, const int32_t ERR, const DEVICE_ERR_CODES_t ERR_
     /* set the timestamp and any error flags to the log message */
     timestamp_FillHeader(&msg->header);
     msg->header.id = DEVICE_ID_GPS;
-
+    
     if (ERR < 0) {
         /* if an error occurred with the FIFO, log the error */
         msg->header.id  |= ERR_CODES;

--- a/firmware/SealHAT/tasks/seal_GPS.h
+++ b/firmware/SealHAT/tasks/seal_GPS.h
@@ -16,6 +16,7 @@
 #define GPS_TASK_PRI    (tskIDLE_PRIORITY + 3)
 #define GPS_MOVINGTIME  ()
 #define GPS_MAXMOVE     (120) /* maximum time in seconds to permit high resolution movement per day  */
+#define GPS_WAIT_TIME   (10000) /* time to wait in ms for a fix */
 
 typedef enum GPS_NOTIFY_VALS {
     GPS_NOTIFY_NONE     = 0x00000000,


### PR DESCRIPTION
Removed many redundant and needless checks that were causing 'false' failures on GPS. Now only checks that I2C is configured correctly. 

Additionally, I removed all of the power saving mode code in favor of manual/timer based sleep modes.

A more flexible block time should still be implemented  (https://www.freertos.org/xTaskCheckForTimeOut.html). Need field testing to ensure that the device can get first fix under new scheme. Ubx library and old gps functions need cleanup, but I'm moving away from that library so I'll do that later.